### PR TITLE
Fix for embedded imath C module

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "flockoffiles/FFDataWrapper" "v1.5"
+github "flockoffiles/FFDataWrapper" "v1.6"

--- a/SwiftySRP.podspec
+++ b/SwiftySRP.podspec
@@ -21,6 +21,6 @@ Pod::Spec.new do |spec|
 
     # Things are listed twice (with different paths) in order to also make it compile as a development pod.
 
-    spec.preserve_paths = 'Scripts/*.sh', 'README', 'SwiftySRPTests/*.swift', 'SwiftySRP/public.modulemap'
+    spec.preserve_paths = 'README', 'SwiftySRPTests/*.swift'
 
 end

--- a/SwiftySRP.podspec
+++ b/SwiftySRP.podspec
@@ -8,22 +8,19 @@ Pod::Spec.new do |spec|
     spec.author       = 'Sergey Novitsky'
     spec.source       = { :git => 'https://github.com/flockoffiles/SwiftySRP.git', :tag => 'v' + String(spec.version) }
     spec.source_files = 'SwiftySRP/*.{h,swift}', 'imath/*.{c,h}'
+    spec.module_map = 'SwiftySRP/private.modulemap'
     spec.exclude_files = 'SwiftySRP/BigIntSpecific/*'
-    spec.public_header_files = 'SwiftySRP/**/*.h'
+    spec.public_header_files = 'SwiftySRP/**/*.h' 
+    spec.private_header_files = 'imath/*.h'
     spec.documentation_url = 'https://github.com/serieuxchat/SwiftySRP/'
     spec.dependency 'FFDataWrapper', '~> 1.6'
     spec.swift_version = '4.1'
+    spec.script_phases = [
+        { :name => 'Fix Module Map', :script => 'rm -rf "$TARGET_BUILD_DIR/$PRODUCT_NAME$WRAPPER_SUFFIX/PrivateHeaders" ; function replace() { export SEARCH="$1" && export REPLACE="$2" && ruby -p -i -e "gsub(ENV[\"SEARCH\"], ENV[\"REPLACE\"])" "$3" ; } ; replace "header \"imath.h\"" "" "${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap" ; replace "header \"imath+additions.h\"" "" "${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap"' }
+    ]
 
     # Things are listed twice (with different paths) in order to also make it compile as a development pod.
 
-    spec.preserve_paths = 'imath/**', 'README', 'SwiftySRPTests/*.swift'
-    spec.xcconfig = {
-        'SWIFT_INCLUDE_PATHS[sdk=iphoneos*]'            => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath',
-        'SWIFT_INCLUDE_PATHS[sdk=iphonesimulator*]'     => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath',
-        'SWIFT_INCLUDE_PATHS[sdk=appletvos*]'           => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath',
-        'SWIFT_INCLUDE_PATHS[sdk=appletvsimulator*]'    => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath',
-        'SWIFT_INCLUDE_PATHS[sdk=watchos*]'             => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath',
-        'SWIFT_INCLUDE_PATHS[sdk=watchsimulator*]'      => '$(PODS_ROOT)/SwiftySRP/imath $(SRCROOT)/../imath'
-    }
+    spec.preserve_paths = 'Scripts/*.sh', 'README', 'SwiftySRPTests/*.swift', 'SwiftySRP/public.modulemap'
 
 end

--- a/SwiftySRP.xcodeproj/project.pbxproj
+++ b/SwiftySRP.xcodeproj/project.pbxproj
@@ -491,7 +491,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Remove module.modulemap file\nrm \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Append the Swift module so you can access you Swift code in Objective-C via @import MyFramework.Swift\necho \"module ${PRODUCT_NAME}.Swift { header \\\"${PRODUCT_NAME}-Swift.h\\\" }\" >> \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
+			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
 			showEnvVarsInLog = 0;
 		};
 		745DDED12243A54800ADFBF4 /* Fix Framework Module Map */ = {
@@ -510,7 +510,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Remove module.modulemap file\nrm \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Append the Swift module so you can access you Swift code in Objective-C via @import MyFramework.Swift\necho \"module ${PRODUCT_NAME}.Swift { header \\\"${PRODUCT_NAME}-Swift.h\\\" }\" >> \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
+			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BD890336167236BD4F0E34CA /* [CP] Check Pods Manifest.lock */ = {

--- a/SwiftySRP.xcodeproj/project.pbxproj
+++ b/SwiftySRP.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		57E011D020403EA0004EDC65 /* BigUInt+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA46851FCC3B2E00DEDF67 /* BigUInt+Extensions.swift */; };
 		57E011D120403EB0004EDC65 /* SRP+BigInt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA46871FCC40F900DEDF67 /* SRP+BigInt.swift */; };
 		57E011D220403EB5004EDC65 /* SRP+BigInt+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA468F1FCC43F400DEDF67 /* SRP+BigInt+Extensions.swift */; };
+		745DDECB2243A3CD00ADFBF4 /* imath.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BF31A81E7A9AA400EC5BCA /* imath.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		745DDECC2243A3CE00ADFBF4 /* imath.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BF31A81E7A9AA400EC5BCA /* imath.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		745DDECD2243A3DD00ADFBF4 /* imath+additions.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BF31AF1E7ABFEE00EC5BCA /* imath+additions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		745DDECE2243A3DE00ADFBF4 /* imath+additions.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BF31AF1E7ABFEE00EC5BCA /* imath+additions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		939F68611F83960D00C4553D /* FFDataWrapper.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 939F68601F83960D00C4553D /* FFDataWrapper.framework */; };
 		A05694BEC3ACB141AF182B03 /* Pods_SwiftySRP_Base_SwiftySRP_SwiftySRPTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0922B69B065556E86D599A64 /* Pods_SwiftySRP_Base_SwiftySRP_SwiftySRPTests.framework */; };
 		A50090BF1E4C74BD00238562 /* SwiftySRP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A50090B51E4C74BD00238562 /* SwiftySRP.framework */; };
@@ -75,6 +79,8 @@
 		57AA46891FCC424E00DEDF67 /* SRP+iMath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRP+iMath.swift"; sourceTree = "<group>"; };
 		57AA468C1FCC436200DEDF67 /* SRP+iMath+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRP+iMath+Extensions.swift"; sourceTree = "<group>"; };
 		57AA468F1FCC43F400DEDF67 /* SRP+BigInt+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SRP+BigInt+Extensions.swift"; sourceTree = "<group>"; };
+		745DDECA2243A1F500ADFBF4 /* private.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = private.modulemap; sourceTree = "<group>"; };
+		745DDECF2243A46100ADFBF4 /* public.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = public.modulemap; sourceTree = "<group>"; };
 		8489902F0C68A50F44D97659 /* Pods-SwiftySRP_Base-SwiftySRP.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftySRP_Base-SwiftySRP.release.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftySRP_Base-SwiftySRP/Pods-SwiftySRP_Base-SwiftySRP.release.xcconfig"; sourceTree = "<group>"; };
 		939F68601F83960D00C4553D /* FFDataWrapper.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FFDataWrapper.framework; path = Carthage/Build/iOS/FFDataWrapper.framework; sourceTree = "<group>"; };
 		A50090B51E4C74BD00238562 /* SwiftySRP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftySRP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -99,7 +105,6 @@
 		A5A56B671E5C34560024CA0A /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		A5BF31A71E7A9AA400EC5BCA /* imath.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = imath.c; sourceTree = "<group>"; };
 		A5BF31A81E7A9AA400EC5BCA /* imath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = imath.h; sourceTree = "<group>"; };
-		A5BF31A91E7A9AA400EC5BCA /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		A5BF31AE1E7ABFEE00EC5BCA /* imath+additions.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = "imath+additions.c"; sourceTree = "<group>"; };
 		A5BF31AF1E7ABFEE00EC5BCA /* imath+additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "imath+additions.h"; sourceTree = "<group>"; };
 		A5D0576F1F5454A1004BC5D6 /* SwiftySRP.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftySRP.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -198,6 +203,8 @@
 		A50090B71E4C74BD00238562 /* SwiftySRP */ = {
 			isa = PBXGroup;
 			children = (
+				745DDECA2243A1F500ADFBF4 /* private.modulemap */,
+				745DDECF2243A46100ADFBF4 /* public.modulemap */,
 				A50090B81E4C74BD00238562 /* SwiftySRP.h */,
 				A50090B91E4C74BD00238562 /* Info.plist */,
 				A5D4B1CD1E7BE9E500BC9A9A /* Configuration */,
@@ -224,7 +231,6 @@
 			children = (
 				A5BF31A71E7A9AA400EC5BCA /* imath.c */,
 				A5BF31A81E7A9AA400EC5BCA /* imath.h */,
-				A5BF31A91E7A9AA400EC5BCA /* module.modulemap */,
 				A5BF31AE1E7ABFEE00EC5BCA /* imath+additions.c */,
 				A5BF31AF1E7ABFEE00EC5BCA /* imath+additions.h */,
 			);
@@ -282,6 +288,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				745DDECB2243A3CD00ADFBF4 /* imath.h in Headers */,
+				745DDECD2243A3DD00ADFBF4 /* imath+additions.h in Headers */,
 				A50090C61E4C74BD00238562 /* SwiftySRP.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -290,6 +298,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				745DDECC2243A3CE00ADFBF4 /* imath.h in Headers */,
+				745DDECE2243A3DE00ADFBF4 /* imath+additions.h in Headers */,
 				A5D057691F5454A1004BC5D6 /* SwiftySRP.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -306,6 +316,7 @@
 				A50090B11E4C74BD00238562 /* Frameworks */,
 				A50090B21E4C74BD00238562 /* Headers */,
 				A50090B31E4C74BD00238562 /* Resources */,
+				745DDED02243A4BF00ADFBF4 /* Fix Framework Module Map */,
 			);
 			buildRules = (
 			);
@@ -344,6 +355,7 @@
 				A5D057661F5454A1004BC5D6 /* Frameworks */,
 				A5D057681F5454A1004BC5D6 /* Headers */,
 				A5D0576A1F5454A1004BC5D6 /* Resources */,
+				745DDED12243A54800ADFBF4 /* Fix Framework Module Map */,
 			);
 			buildRules = (
 			);
@@ -461,6 +473,44 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		745DDED02243A4BF00ADFBF4 /* Fix Framework Module Map */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Fix Framework Module Map";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Remove module.modulemap file\nrm \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Append the Swift module so you can access you Swift code in Objective-C via @import MyFramework.Swift\necho \"module ${PRODUCT_NAME}.Swift { header \\\"${PRODUCT_NAME}-Swift.h\\\" }\" >> \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
+			showEnvVarsInLog = 0;
+		};
+		745DDED12243A54800ADFBF4 /* Fix Framework Module Map */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Fix Framework Module Map";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Delete PrivateHeaders folder\nrm -rf \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/PrivateHeaders\"\n\n# Remove module.modulemap file\nrm \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Copy public.modulemap file and rename it to module.modulemap\ncp \"${SRCROOT}/SwiftySRP/public.modulemap\" \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n\n# Append the Swift module so you can access you Swift code in Objective-C via @import MyFramework.Swift\necho \"module ${PRODUCT_NAME}.Swift { header \\\"${PRODUCT_NAME}-Swift.h\\\" }\" >> \"${TARGET_BUILD_DIR}/${PRODUCT_NAME}${WRAPPER_SUFFIX}/Modules/module.modulemap\"\n";
 			showEnvVarsInLog = 0;
 		};
 		BD890336167236BD4F0E34CA /* [CP] Check Pods Manifest.lock */ = {
@@ -688,11 +738,11 @@
 				INFOPLIST_FILE = SwiftySRP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = SwiftySRP/private.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flockoffiles.SwiftySRP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/imath";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 			};
@@ -713,11 +763,11 @@
 				INFOPLIST_FILE = SwiftySRP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = SwiftySRP/private.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flockoffiles.SwiftySRP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/imath";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -776,10 +826,10 @@
 				INFOPLIST_FILE = SwiftySRP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = SwiftySRP/private.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flockoffiles.SwiftySRP;
 				PRODUCT_NAME = SwiftySRP;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/imath";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 			};
@@ -802,10 +852,10 @@
 				INFOPLIST_FILE = SwiftySRP/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = SwiftySRP/private.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.flockoffiles.SwiftySRP;
 				PRODUCT_NAME = SwiftySRP;
 				SKIP_INSTALL = YES;
-				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/imath";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;

--- a/SwiftySRP/SRPMpzT.swift
+++ b/SwiftySRP/SRPMpzT.swift
@@ -24,7 +24,6 @@
 //  SOFTWARE.
 
 import Foundation
-import imath
 import FFDataWrapper
 
 /// This class wraps an mpz_t value from imath and provides methods to conform to SRPBigIntProtocol

--- a/SwiftySRP/private.modulemap
+++ b/SwiftySRP/private.modulemap
@@ -1,0 +1,10 @@
+framework module SwiftySRP {
+
+    umbrella header "SwiftySRP.h"
+
+    export *
+    module * {export *}
+
+    header "imath.h"
+    header "imath+additions.h"
+}

--- a/SwiftySRP/public.modulemap
+++ b/SwiftySRP/public.modulemap
@@ -5,3 +5,8 @@ framework module SwiftySRP {
     export *
     module * {export *}
 }
+
+module SwiftySRP.Swift {
+    header "SwiftySRP-Swift.h"
+    requires objc
+}

--- a/SwiftySRP/public.modulemap
+++ b/SwiftySRP/public.modulemap
@@ -1,0 +1,7 @@
+framework module SwiftySRP {
+
+    umbrella header "SwiftySRP.h"
+
+    export *
+    module * {export *}
+}

--- a/imath/module.modulemap
+++ b/imath/module.modulemap
@@ -1,6 +1,0 @@
-module imath {
-  header "imath.h"
-  header "imath+additions.h"
-  export *
-}
-


### PR DESCRIPTION
Fix for the embedded imath module such that it is not embedded using its own module.modulemap anymore which results in precarious compilation problems for clients of SwiftySRP (original absolute path to the modulemap needs to be present, otherwise compilation will fail).

This instead uses the trick described on stackoverflow: https://stackoverflow.com/a/38382141/480467